### PR TITLE
Add get group test

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -108,6 +108,8 @@ app.post("/group", async (req: Request, res: Response): Promise<any> => {
     return res.status(400).send(UNAUTHENTICATED_ORGANIZER_REQUEST);
   }
 
+  // todo: for some reason the tests result in orgSession being a string instead of Object,
+  //   for now if its a string parse it.
   if (typeof orgSession === 'string') {
     orgSession = JSON.parse(orgSession);
   }
@@ -151,6 +153,12 @@ app.get("/group", async (req: Request, res: Response): Promise<any> => {
 
   if (!orgSession) {
     return res.status(400).send(UNAUTHENTICATED_ORGANIZER_REQUEST);
+  }
+
+  // todo: for some reason the tests result in orgSession being a string instead of Object,
+  //   for now if its a string parse it.
+  if (typeof orgSession === 'string') {
+    orgSession = JSON.parse(orgSession);
   }
 
   const getGroupSql = `

--- a/tests/integration/group.test.ts
+++ b/tests/integration/group.test.ts
@@ -46,5 +46,34 @@ describe('POST /group', () => {
     // DB should still have just one row
     const rows2 = await db.allAsync(`SELECT * FROM group_entity`);
     expect(rows2.length).toBe(1);
+
+    //get group call should return 1 group
+    const getGroupRes = await request(app)
+      .get('/group')
+      .set('Cookie', cookie);
+    
+    expect(JSON.parse(getGroupRes.text)).toEqual([
+      {
+        id: 1,
+        name: 'Dinner season one',
+        description: 'a dinner among friends',
+        rules: 'be cool',
+        questions: [],
+      },
+    ]);
+  });
+
+  it('getting group returns empty list if none found', async () => {
+    const cookie = CookieHelper.generateSignedCookie(
+      Constants.orgSessionCookieName,
+      { org_id: 1 },
+      secretKey
+    );
+
+    const getGroupRes = await request(app)
+      .get('/group')
+      .set('Cookie', cookie);
+    
+    expect(getGroupRes.text).toBe("[]");
   });
 });


### PR DESCRIPTION
Add test for get /group in the duplicate group test.

Add test for empty groups.

Add explanation for why i convert orgSession to an object which is because the tests are making it a string for some unknown reason i can't figure out.